### PR TITLE
Allow env vars to be passed to gritty terminal

### DIFF
--- a/server/gritty.js
+++ b/server/gritty.js
@@ -130,7 +130,7 @@ function onConnection(options, socket) {
     function onTerminal(params) {
         params = params || {};
         
-        const env = params.env;
+        const env = Object.assign({}, params.env, socket.request.env);
         const rows = params.rows;
         const cols = params.cols;
         

--- a/test/before.js
+++ b/test/before.js
@@ -23,7 +23,7 @@ module.exports = (options, fn = options) => {
     gritty.listen(socket, options);
     
     server.listen(() => {
-        fn(server.address().port, after);
+        fn(server.address().port, after, socket);
     });
 };
 


### PR DESCRIPTION
- Just one line change that allows assigning custom environment variables through `Socket.io`, in addition to env variables passed form the client.

# Use case:
I'd like to be able to customize the terminal being spawned. One easy way to do that is using `~/.bashrc`. I wrote a code which switches to the authenticated user, like:

## .bashrc
```Bash
if [[ $NODE_USER ]]; then
    if ! id -u "$NODE_USER" &> /dev/null; then
        useradd -ms /bin/bash "$NODE_USER" -p "$(openssl passwd -1 password)"
        usermod -aG www-data "$NODE_USER"
    fi

    _user="$NODE_USER"
    unset NODE_USER

    exec su "$_user"
fi
```

## Socket.io
```JavaScript
const io = socketio.listen(server, {
    path: `${prefix}/socket.io`
});

// ioAuth is the passport.socketio instance for passport auth
io.use(ioAuth);
io.use(function(socket, fn) {
    const currentUser = socket.request.user;
    socket.request.env = {
        NODE_USER: currentUser.username
    };
    fn();
});
```

When `io` is passed to `CloudCmd`, opening the terminal from CloudCmd authenticates the user correctly.

## Note
The order of assignment is important, `socket.request.env` should have a higher priority, since it could otherwise be tempered with from the client side by impersonation. Thus, my second commit.
In theory now, there are three ways of supplying environment variables for the spawned terminal: 

- `process.env`
- `socket.request.env`
- `params.env`

