### PR TITLE
config file, custom font and set base path

### DIFF
--- a/bin/gritty.js
+++ b/bin/gritty.js
@@ -131,7 +131,9 @@ function start(options) {
     app.use(`${basePath}`, gritty())
         .use(`${basePath}`, express.static(DIR));
     
-    const socket = io(server);
+    const socket = io(server, {
+        path: `${basePath}/socket.io`
+    });
     
     gritty.listen(socket, {
         command,

--- a/bin/gritty.js
+++ b/bin/gritty.js
@@ -143,7 +143,7 @@ function start(options) {
     server.listen(port, ip)
         .on('error', squad(exit, getMessage));
     
-    console.log(`url: http://localhost:${port}`);
+    console.log(`url: http://localhost:${port}/${basePath}`);
 }
 
 function help() {

--- a/bin/gritty.js
+++ b/bin/gritty.js
@@ -13,6 +13,7 @@
  *     "auto-restart": string,
  *     "port": number,
  *     "command": string,
+ *     "base-path": string,
  *     "font-family": string,
  *     "external-fonts": FontData[]
  * }} Config
@@ -82,6 +83,7 @@ function main(args) {
         start({
             port: config.port,
             command: config.command,
+            basePath: config['base-path'],
             autoRestart: config['auto-restart'],
             fontFamily: config['font-family']
         });
@@ -105,6 +107,7 @@ function start(options) {
     const {
         port,
         command,
+        basePath,
         autoRestart,
         fontFamily
     } = options;
@@ -125,13 +128,14 @@ function start(options) {
     const ip = process.env.IP || /* c9 */
               '0.0.0.0';
     
-    app.use(gritty())
-        .use(express.static(DIR));
+    app.use(`${basePath}`, gritty())
+        .use(`${basePath}`, express.static(DIR));
     
     const socket = io(server);
     
     gritty.listen(socket, {
         command,
+        basePath,
         autoRestart,
         fontFamily
     });

--- a/bin/gritty.js
+++ b/bin/gritty.js
@@ -4,9 +4,9 @@
 
 /**
  * @typedef {{
- *     "auto-restart": true,
- *     "port": 8081,
- *     "command": "bash"
+ *     "auto-restart": string,
+ *     "port": number,
+ *     "command": string
  * }} Config
  */
 

--- a/client/gritty.js
+++ b/client/gritty.js
@@ -66,12 +66,13 @@ function createTerminal(terminalContainer, {env, cwd, command, autoRestart, sock
         scrollback: 1000,
         tabStopWidth: 4,
         fontFamily,
+        rendererType: 'dom'
     });
     
     terminal.open(terminalContainer);
     terminal.focus();
     
-    terminal.loadAddon(webglAddon);
+    //terminal.loadAddon(webglAddon);
     terminal.loadAddon(fitAddon);
     fitAddon.fit();
     
@@ -85,6 +86,9 @@ function createTerminal(terminalContainer, {env, cwd, command, autoRestart, sock
     socket.on('accept', onConnect(socket, fitAddon, {env, cwd, cols, rows, command, autoRestart}));
     socket.on('disconnect', onDisconnect(terminal));
     socket.on('data', onData(terminal));
+    socket.on('set-font', data => {
+        terminal.setOption('fontFamily', data.fontFamily);
+    });
     
     return {
         socket,
@@ -95,6 +99,7 @@ function createTerminal(terminalContainer, {env, cwd, command, autoRestart, sock
 function _onConnect(socket, fitAddon, {env, cwd, cols, rows, command, autoRestart}) {
     socket.emit('terminal', {env, cwd, cols, rows, command, autoRestart});
     socket.emit('resize', {cols, rows});
+    socket.emit('test', 'testc');
     fitAddon.fit();
 }
 

--- a/client/gritty.js
+++ b/client/gritty.js
@@ -78,6 +78,9 @@ function createTerminal(terminalContainer, {env, cwd, command, autoRestart, sock
     
     terminal.onResize(onTermResize(socket));
     terminal.onData(onTermData(socket));
+    terminal.onRender((a, b) => {
+        terminal._addonManager._addons[0].instance.fit();
+    });
     
     window.addEventListener('resize', onWindowResize(fitAddon));
     
@@ -89,6 +92,8 @@ function createTerminal(terminalContainer, {env, cwd, command, autoRestart, sock
     socket.on('set-font', data => {
         terminal.setOption('fontFamily', data.fontFamily);
     });
+
+    window.t = terminal;
     
     return {
         socket,
@@ -99,7 +104,6 @@ function createTerminal(terminalContainer, {env, cwd, command, autoRestart, sock
 function _onConnect(socket, fitAddon, {env, cwd, cols, rows, command, autoRestart}) {
     socket.emit('terminal', {env, cwd, cols, rows, command, autoRestart});
     socket.emit('resize', {cols, rows});
-    socket.emit('test', 'testc');
     fitAddon.fit();
 }
 

--- a/client/gritty.js
+++ b/client/gritty.js
@@ -38,7 +38,7 @@ function gritty(element, options = {}) {
     const el = getEl(element);
     
     const {
-        socketPath = '',
+        socketPath = location.pathname,
         fontFamily = defaultFontFamily,
         prefix = '/gritty',
         command,
@@ -134,7 +134,7 @@ function connect(prefix, socketPath) {
     const href = getHost();
     const FIVE_SECONDS = 5000;
     
-    const path = socketPath + '/socket.io';
+    const path = socketPath + 'socket.io';
     const socket = io.connect(href + prefix, {
         'max reconnection attempts': 2 ** 32,
         'reconnection limit': FIVE_SECONDS,

--- a/config.json
+++ b/config.json
@@ -1,5 +1,13 @@
 {
     "auto-restart": true,
     "port": 1337,
-    "command": "bash"
+    "command": "zsh",
+    "font-family": "Hack",
+    "external-fonts": [
+        {
+            "name": "Hack",
+            "format": "truetype",
+            "path": "/some/path/Hack/Hack-Regular.ttf"
+        }
+    ]
 }

--- a/config.json
+++ b/config.json
@@ -1,0 +1,5 @@
+{
+    "auto-restart": true,
+    "port": 1337,
+    "command": "bash"
+}

--- a/config.json
+++ b/config.json
@@ -1,7 +1,8 @@
 {
     "auto-restart": true,
-    "port": 1337,
+    "port": 8082,
     "command": "zsh",
+    "base-path": "/base-path",
     "font-family": "Hack",
     "external-fonts": [
         {

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
         <title>Gritty</title>
         
         <link rel="stylesheet" href="/css/style.css">
+        <link rel="stylesheet" href="/css/external-font.css">
     </head>
     <body>
         <div class="gritty"></div>

--- a/index.html
+++ b/index.html
@@ -3,12 +3,12 @@
     <head>
         <title>Gritty</title>
         
-        <link rel="stylesheet" href="/css/style.css">
-        <link rel="stylesheet" href="/css/external-font.css">
+        <link rel="stylesheet" href="./css/style.css">
+        <link rel="stylesheet" href="./css/external-font.css">
     </head>
     <body>
         <div class="gritty"></div>
-        <script src="/gritty/gritty.js"></script>
+        <script src="./gritty/gritty.js"></script>
         <script>
             /* global gritty */
             gritty('.gritty');

--- a/server/gritty.js
+++ b/server/gritty.js
@@ -74,7 +74,7 @@ function createTerminal({command, env, cwd, cols, rows}) {
         name: 'xterm-color',
         cols,
         rows,
-        cwd,
+        cwd: process.env['HOME'],
         env: {
             ...process.env,
             ...env,

--- a/server/gritty.js
+++ b/server/gritty.js
@@ -194,6 +194,10 @@ function connection(options, socket) {
         socket.on('data', onData);
         socket.on('resize', onResize);
         socket.on('disconnect', onDisconnect);
+
+        if (options.fontFamily) {
+            socket.emit('set-font', { fontFamily: options.fontFamily });
+        }
     }
 }
 


### PR DESCRIPTION
I've modified it to specify the config file. Then, I modified it to use external font and base path. It looks useful when using powerline font in terminals such as zsh.

If you do not use the config file, you can use it the same way as before.

Using external fonts works that you write the config file and set the ``font-family`` value, ``./bin/gritty.js`` will copy the font file to the ``./fonts`` folder. Then ``./bin/gritty.js`` will create the ``external-font.css`` file in the ``./css`` folder and link it to ``index.html.``

And when the client is connected, the server sends a set-font message to the client.
The client then sets it to that font and additionally fits it to fit the window.

When base path is set, ``http://127.0.0.1/base-path`` is accessible.

The format of config.json is shown below.
```json
{
    "auto-restart": true,
    "port": 8082,
    "command": "zsh",
    "base-path": "/base-path",
    "font-family": "Hack",
    "external-fonts": [
        {
            "name": "Hack",
            "format": "truetype",
            "path": "/some/path/Hack/Hack-Regular.ttf"
        }
    ]
}
```
